### PR TITLE
Change spacing and visibility for business names

### DIFF
--- a/_sass/_default.scss
+++ b/_sass/_default.scss
@@ -31,6 +31,10 @@ h1 {
 h2 {
 	font-size: 40px;
 	padding: 40px 0 30px 0;
+
+    &#letter {
+      padding-bottom: 10px;
+    }
 }
 
 strong {
@@ -216,7 +220,7 @@ hr {
 }
 
 .letter-content {
-	margin: 100px auto;
+	margin: 30px auto 100px;
 	max-width: 850px;
 	text-align: left;
 	color: white;

--- a/index.md
+++ b/index.md
@@ -555,9 +555,9 @@ See over 100 more
 </div>
 {::options parse_block_html="true" /}
 
-# Read the Letter
+## Read the Letter
 {: #letter }
-<strong>Download the PDF</strong>
+[Download the PDF]()
 
 <div class="letter-content">
 


### PR DESCRIPTION
1. Can we change the line spacing for the list of businesses to be the same as how they are spaced at `keepthewebopenforbusiness.com` (you'll see the difference right away when you compare the two pages)? You might be able to steal the CSS spacing right out of that page.

2. Right now two lines of listed businesses are visible before you click "See over 100 more." Can we make it so 5 lines of businesses are visible before you click that button? Images below:

![keepthewebopen-spacing](https://user-images.githubusercontent.com/29211877/30825659-99551b8c-a1e8-11e7-89b1-9d061aa97816.png)
![theworldfornetneutrlaity-spacing](https://user-images.githubusercontent.com/29211877/30825658-99412d0c-a1e8-11e7-93b4-b54d524b365b.png)

